### PR TITLE
Fix ejecting and add analyze mode

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -30,6 +30,9 @@ const publicUrl = '';
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
 
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const isAnalyzeMode = process && process.env && process.env.ANALYZE;
+
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
 // The production configuration is different and lives in a separate file.
@@ -274,6 +277,9 @@ module.exports = {
     // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
     // You can remove this if you don't use Moment.js:
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+
+    // if we're not in analyze mode return a dummy function so webpack won't fail
+    isAnalyzeMode ? new BundleAnalyzerPlugin() : () => {}
   ],
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@500tech/react-scripts",
-  "version": "1.1.2",
+  "version": "1.1.3-beta.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",
@@ -67,7 +67,8 @@
     "webpack": "3.8.1",
     "webpack-dev-server": "2.9.4",
     "webpack-manifest-plugin": "1.3.2",
-    "whatwg-fetch": "2.0.3"
+    "whatwg-fetch": "2.0.3",
+    "webpack-bundle-analyzer": "2.11.1"
   },
   "devDependencies": {
     "husky": "^0.14.3",

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -207,7 +207,7 @@ inquirer
     // Add Babel config
     console.log(`  Adding ${cyan('Babel')} preset`);
     appPackage.babel = {
-      presets: ['react-app'],
+      presets: ['@500tech/babel-preset-react-app'],
     };
 
     // Add ESlint config


### PR DESCRIPTION
This is published in beta version on npm: `1.1.3-beta.1` tagged as next
you can install it by running `npm install @500tech/react-scripts@next`

Once this is approved we can publish an official update.

What this did:
1. It fixed not using our own fork of babel-preset so it did not support all the features used in the project leading to a build failure after ejecting
2. When specifying ANALYZE=true as an environment variable (in development only) it adds the webpack-bundle-analyzer plugin and opens the tree view in localhost:8888 (opens automatically in your default browser)